### PR TITLE
Fix panic when GetNetworkByIP returns 'not found error'

### DIFF
--- a/pkg/ipam/network.go
+++ b/pkg/ipam/network.go
@@ -94,8 +94,11 @@ func getNetwork(r *storage.Redis, ipnet *net.IPNet) (*model.Network, error) {
 	dkey := makeNetworkDetailsKey(ipnet)
 
 	check, err := r.Client.Exists(dkey).Result()
-	if err != nil || check == 0 {
+	if err != nil {
 		return nil, errors.Wrap(err, "not found Network")
+	}
+	if check == 0 {
+		return nil, errors.New("not found Network")
 	}
 
 	data, err := r.Client.Get(dkey).Result()


### PR DESCRIPTION
Fix the following panic error. 

```
time="2017-10-23T15:19:47+09:00" level=error msg="panic grpc: err=runtime error: invalid memory address or nil pointer dereference, stack:
goroutine 424 [running]:
github.com/taku-k/ipdrawer/pkg/server.recoveryFunc(0xaa9080, 0x1239100, 0xc4208f8f80, 0x0)
        /Users/taku_k/go/src/github.com/taku-k/ipdrawer/pkg/server/recovery.go:18 +0x82
github.com/taku-k/ipdrawer/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom(0xaa9080, 0x1239100, 0xbad9e0, 0x15, 0xc4203a7380)
        /Users/taku_k/go/src/github.com/taku-k/ipdrawer/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/interceptors.go:47 +0x43
github.com/taku-k/ipdrawer/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1(0xc4203a7730, 0xc42022e078)
        /Users/taku_k/go/src/github.com/taku-k/ipdrawer/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/interceptors.go:21 +0x63
panic(0xaa9080, 0x1239100)
        /usr/local/opt/go/libexec/src/runtime/panic.go:491 +0x283
github.com/taku-k/ipdrawer/pkg/server.(*APIServer).GetNetwork(0xc42025e1e0, 0xf79420, 0xc42020fad0, 0xc42020f980, 0xc42025e1e0, 0x2b5b63fa, 0x1888699159512)
        /Users/taku_k/go/src/github.com/taku-k/ipdrawer/pkg/server/api.go:353 +0x1a7
github.com/taku-k/ipdrawer/pkg/server/serverpb._NetworkServiceV0_GetNetwork_Handler.func1(0xf79420, 0xc42020fad0, 0xb2b6a0, 0xc42020f980, 0x25, 0xf79420, 0xc42020fad0, 0x30)
```